### PR TITLE
エラーを吐いていた原因を解消するリクエスト

### DIFF
--- a/pages/index.js
+++ b/pages/index.js
@@ -37,6 +37,7 @@ export default function Home({articles,lessons}) {
       <div className="mb-32 grid text-center lg:mb-0 lg:grid-cols-4 lg:text-left">
         {articles.map((article) => (
           <a
+          key={article.id}
           href="https://nextjs.org/docs?utm_source=create-next-app&utm_medium=default-template-tw&utm_campaign=create-next-app"
           className="group rounded-lg border border-transparent px-5 py-4 transition-colors hover:border-gray-300 hover:bg-gray-100 hover:dark:border-neutral-700 hover:dark:bg-neutral-800/30"
           target="_blank"

--- a/pages/profile.js
+++ b/pages/profile.js
@@ -1,15 +1,17 @@
 import { useState, useEffect } from 'react';
-import { supabase } from '../client'
+// import { supabase } from '../client'
 import { useRouter } from 'next/router'
+import { useSupabaseClient } from '@supabase/auth-helpers-react';
 
 export default function Profile() {
+  const supabase = useSupabaseClient();
   const [profile, setProfile] = useState(null)
   const router = useRouter()
   useEffect(() => {
     fetchProfile()
   }, [])
   async function update() {
-    const { user, error } = await supabase.auth.update({ 
+    const { user, error } = await supabase.auth.updateUser({ 
       data: {
         city: "New York"
       } 
@@ -17,17 +19,17 @@ export default function Profile() {
     console.log('user:', user);
   }
   async function fetchProfile() {
-    const profileData = await supabase.auth.user()
+    const {data: { user: profileData }} = await supabase.auth.getUser()
     console.log("profileData: ", profileData)
     if (!profileData) {
-      router.push('/sign-in')
+      router.push('/login')
     } else {
       setProfile(profileData)
     }
   }
   async function signOut() {
     await supabase.auth.signOut()
-    router.push('/sign-in')
+    router.push('/login')
   }
   if (!profile) return null
   return (

--- a/pages/protected.js
+++ b/pages/protected.js
@@ -1,4 +1,5 @@
-import { supabase } from '../client'
+import { createServerSupabaseClient } from "@supabase/auth-helpers-nextjs";
+
 
 export default function Protected({ user }) {
   console.log({ user })
@@ -9,12 +10,14 @@ export default function Protected({ user }) {
   )
 }
 
-export async function getServerSideProps({ req }) {
-  const { user } = await supabase.auth.api.getUserByCookie(req)
+export async function getServerSideProps(context) {
+  const { req } = context;
+  const supabase = createServerSupabaseClient({req})
+  const {data: { session }} = await supabase.auth.getSession();
 
-  if (!user) {
-    return { props: {}, redirect: { destination: '/sign-in' } }
+  if (!session) {
+    return { props: {}, redirect: { destination: '/login' } }
   }
 
-  return { props: { user } }
+  return { props: { user: session.user } }
 }


### PR DESCRIPTION
# 主なエラーの原因

## keyの不足が原因
<img width="500" alt="スクリーンショット 2023-05-24 21 25 13" src="https://github.com/kaikunnnn/bonoSite/assets/10560950/7e906517-8884-4793-91af-a84aee2e9ecf">

Reactではmapを使用した際に、一番外側の親に対して`key`を付与する必要があるので追加しました。もし、`article.id`の`id`が存在しない場合は適宜変更をお願いします（`article.article_id`など）

## ユーザーデータの取得方法について

### ユーザーデータ

> - ログインログオフ機能はできてる
> - sessionでユーザーデータも取れてる

supabaseのauth-helperを使用していますが、もしかしたらチュートリアル内のデータ取得方法（未確認）の内容がoutdatedかもしれません。[ドキュメントはこちらが最新となります](https://supabase.com/docs/guides/auth/auth-helpers/nextjs)

また `../client`経由でsupabaseを呼び出している箇所もありましたが、フォルダが存在していなかったのと、こちらはヘルパーの `useUser()`や`useSession()`で代用できるので`signup.js`ページの要領で使用がおすすめです。


### Stripe情報

>   が、**stripe_IDとかis_subscribeのテーブル情報は出てない（これがあんまりわかってない。出す必要もないのかもだけど？**

こちらに関しては、`useUser()`や`getSession()`などによって取得するユーザーデータはsupabaseのauth.usersという特別なテーブル経由から取得しているので、stripeやその他の情報は含まれていません。

```javascript
// 例として、こちらはusersテーブルからユーザー情報を取得する
const { data: user } = await supabase.from('users').select().match({id}).single()

// こちらはsupabase内部に自動で作られる特別なテーブルから取得している
const {data: { user }} = await supabase.auth.getUser();
```

そして、stripe_IDやis_subscribeのテーブル情報を出すべきかはセキュリティ面から考えて確認が必要なので別途確認します！現状、それらの情報が取得できていないのは通常通りなので問題はないです。

## 課金ユーザーか否かでのページの出しわけ

こちらはチュートリアルでどのように処理を行っているのか別途確認が必要なので別途確認が必要です🙏

方法としては、

- RLSやSQLで処理をしている
- 単純にif is_subscribed = trueなら表示する、のように処理をしている

があると思いますが、自分も把握しきれていないので別途確認が必要です！
